### PR TITLE
Schema inner meta

### DIFF
--- a/snow/exceptions.py
+++ b/snow/exceptions.py
@@ -70,6 +70,10 @@ class SelectError(SnowException):
     """Raised on query builder issues"""
 
 
+class NoSchemaLocation(SnowException):
+    """Raised if a snow.resource.Schema doesn't have an inner Meta location property set"""
+
+
 class NoSchemaFields(SnowException):
     """The schema lacks fields definitions"""
 

--- a/snow/resource/__init__.py
+++ b/snow/resource/__init__.py
@@ -56,7 +56,7 @@ class Resource:
         # Build URL
         url_schema = "https://" if self.config.use_ssl else "http://"
         base_url = url_schema + str(self.config.address)
-        self.url = urljoin(base_url, str(schema_cls.__location__))
+        self.url = urljoin(base_url, str(schema_cls.Meta.location))
 
         # Read Resource schema
         self.schema = schema_cls(unknown=marshmallow.EXCLUDE)  # type: Schema

--- a/tests/app/test_app_resource_schema.py
+++ b/tests/app/test_app_resource_schema.py
@@ -15,6 +15,17 @@ def test_schema_missing_location(mock_app_raw):
         app.resource(TestSchema)
 
 
+def test_schema_invalid_type(mock_app_raw):
+    """Schema of unknown type should raise UnexpectedSchema"""
+
+    class TestSchema:
+        test = fields.Text()
+
+    app = mock_app_raw
+    with pytest.raises(UnexpectedSchema):
+        app.resource(TestSchema)
+
+
 def test_schema_valid_location(mock_app_raw):
     """Schema with a valid location should work"""
 

--- a/tests/app/test_app_resource_schema.py
+++ b/tests/app/test_app_resource_schema.py
@@ -1,0 +1,44 @@
+import pytest
+
+from snow.resource import Schema, fields
+from snow.exceptions import NoSchemaLocation, UnexpectedSchema
+
+
+def test_schema_missing_location(mock_app_raw):
+    """Schema missing Meta.location should raise NoSchemaLocation"""
+
+    class TestSchema(Schema):
+        test = fields.Text()
+
+    app = mock_app_raw
+    with pytest.raises(NoSchemaLocation):
+        app.resource(TestSchema)
+
+
+def test_schema_valid_location(mock_app_raw):
+    """Schema with a valid location should work"""
+
+    class TestSchema(Schema):
+        class Meta:
+            location = "/test"
+
+        test = fields.Text()
+
+    app = mock_app_raw
+    resource = app.resource(TestSchema)
+    assert resource.schema.snow_meta.location == "/test"
+
+
+def test_schema_invalid_location(mock_app_raw):
+    """Schema with an invalid location should fail"""
+
+    class TestSchema(Schema):
+        class Meta:
+            location = "test"
+
+        test = fields.Text()
+
+    app = mock_app_raw
+
+    with pytest.raises(UnexpectedSchema):
+        app.resource(TestSchema)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,15 +38,20 @@ def mock_client(aiohttp_client):
 
 
 @pytest.fixture
-def mock_app(mock_client):
-    async def go(connect_to):
-        app = Application(
-            config_data=dict(
-                address="test.service-now.com",
-                basic_auth=("test", "test"),
-                use_ssl=False,
-            )
+def mock_app_raw():
+    return Application(
+        config_data=dict(
+            address="test.service-now.com",
+            basic_auth=("test", "test"),
+            use_ssl=False,
         )
+    )
+
+
+@pytest.fixture
+def mock_app(mock_app_raw, mock_client):
+    async def go(connect_to):
+        app = mock_app_raw
         get_session = await mock_client(connect_to)
         app.get_session = lambda: get_session
         return app


### PR DESCRIPTION
This moves schema API location assignment from  `Schema.__location__` to `Schema.Meta.location`. The `Meta` object is made available in `Schema.snow_meta` after registration.

```python
class MySchema(Schema):
    class Meta:
        location = "/test"

    my_field = fields.Text()
```
