### PR TITLE
Rework Application argument handling

### DIFF
--- a/snow/__init__.py
+++ b/snow/__init__.py
@@ -4,16 +4,18 @@ from typing import Type
 import aiohttp
 from marshmallow import ValidationError
 
-from .config import ConfigSchema
-from .consts import Joined
-from .exceptions import ConfigurationException, NoAuthenticationMethod, UnexpectedSchema
-from .request.response import Response
-from .resource import QueryBuilder, Resource, Schema, select
-from .session import Session
-
-
-def load_config(config_data: dict) -> ConfigSchema:
-    return ConfigSchema().load(config_data)
+from snow.config import ConfigSchema
+from snow.consts import Joined
+from snow.exceptions import (
+    ConfigurationException,
+    IncompatibleSession,
+    InvalidSessionType,
+    NoAuthenticationMethod,
+    UnexpectedSchema,
+)
+from snow.request.response import Response
+from snow.resource import QueryBuilder, Resource, Schema, select
+from snow.session import Session
 
 
 class Application:
@@ -25,15 +27,38 @@ class Application:
         - ClientSession factory
 
     Args:
-        config_data: Config dictionary
+        session: Session config dictionary or a Custom snow.Session object
 
     Attributes:
         config: Application configuration object
     """
 
-    def __init__(self, config_data: dict):
+    _preconf_session = None
+
+    def __init__(
+        self,
+        address: str,
+        basic_auth: tuple = None,
+        use_ssl: bool = True,
+        verify_ssl: bool = True,
+        session: Session = None,
+    ):
+        app_config = dict(address=address)
+
+        if session:
+            if not isinstance(session, Session):
+                raise InvalidSessionType(
+                    f"The snow.Application expects session to be a {Session}, not {session}"
+                )
+
+            self._preconf_session = session
+        else:
+            app_config["session"] = dict(
+                basic_auth=basic_auth, use_ssl=use_ssl, verify_ssl=verify_ssl
+            )
+
         try:
-            self.config = load_config(config_data)
+            self.config = ConfigSchema(many=False).load(app_config)
         except ValidationError as e:
             raise ConfigurationException(e)
 
@@ -45,8 +70,8 @@ class Application:
             aiohttp-compatible authentication object
         """
 
-        if self.config.basic_auth:
-            return aiohttp.BasicAuth(*self.config.basic_auth)  # type: ignore
+        if self.config.session.basic_auth:
+            return aiohttp.BasicAuth(*self.config.session.basic_auth)  # type: ignore
         else:
             raise NoAuthenticationMethod("No known authentication methods was provided")
 
@@ -60,10 +85,13 @@ class Application:
             NoAuthenticationMethod
         """
 
+        if self._preconf_session:
+            return self._preconf_session
+
         connector_args = {}  # type: dict
 
-        if self.config.use_ssl:
-            connector_args["verify_ssl"] = self.config.verify_ssl
+        if self.config.session.use_ssl:
+            connector_args["verify_ssl"] = self.config.session.verify_ssl
 
         return Session(
             auth=self._auth, connector=aiohttp.TCPConnector(**connector_args)

--- a/snow/config.py
+++ b/snow/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from marshmallow import Schema, ValidationError, fields, post_load
+
 from snow.exceptions import ConfigurationException
 
 
@@ -60,7 +61,7 @@ class ConfigSchema(BaseConfigSchema):
         session (bool): Session config
     """
 
-    address = fields.String(required=True)  # type: str
+    address = fields.String(required=True)
     session = fields.Nested(
         SessionConfig, required=False
     )  # type: SessionConfig # type: ignore

--- a/snow/exceptions.py
+++ b/snow/exceptions.py
@@ -2,10 +2,6 @@ class SnowException(Exception):
     pass
 
 
-class InvalidSessionType(SnowException):
-    """Invalid session type provided to Application"""
-
-
 class ConfigurationException(SnowException):
     """Configuration error"""
 

--- a/snow/exceptions.py
+++ b/snow/exceptions.py
@@ -2,6 +2,10 @@ class SnowException(Exception):
     pass
 
 
+class InvalidSessionType(SnowException):
+    """Invalid session type provided to Application"""
+
+
 class ConfigurationException(SnowException):
     """Configuration error"""
 
@@ -52,6 +56,10 @@ class IncompatiblePayloadField(SnowException):
 
 class UnknownPayloadField(SnowException):
     """A field unknown to the schema was found in the payload"""
+
+
+class IncompatibleSession(SnowException):
+    """Raised if a custom session object passed to snow.Application is not of snow.Session type"""
 
 
 class UnexpectedSchema(SnowException):

--- a/snow/request/__init__.py
+++ b/snow/request/__init__.py
@@ -3,3 +3,4 @@ from .get import GetRequest
 from .helpers import Pagestream
 from .patch import PatchRequest
 from .post import PostRequest
+from .response import Response

--- a/snow/request/base.py
+++ b/snow/request/base.py
@@ -10,8 +10,8 @@ from aiohttp import client_exceptions
 
 from snow.consts import CONTENT_TYPE
 from snow.exceptions import ClientConnectionError, UnexpectedContentType
-from snow.request.response import Response
-from snow.session import Session
+
+from .response import Response
 
 if TYPE_CHECKING:
     from snow import Resource
@@ -21,7 +21,7 @@ _cache: dict = {}
 
 
 class Request(ABC):
-    session: Session
+    session: Any
     log = logging.getLogger("snow.request")
 
     def __init__(self, resource: Resource):

--- a/snow/resource/__init__.py
+++ b/snow/resource/__init__.py
@@ -54,7 +54,7 @@ class Resource:
         self.config = self.app.config
 
         # Build URL
-        url_schema = "https://" if self.config.use_ssl else "http://"
+        url_schema = "https://" if self.config.session.use_ssl else "http://"
         base_url = url_schema + str(self.config.address)
         self.url = urljoin(base_url, str(schema_cls.__location__))
 

--- a/snow/resource/__init__.py
+++ b/snow/resource/__init__.py
@@ -22,8 +22,8 @@ from snow.request import (
     Pagestream,
     PatchRequest,
     PostRequest,
+    Response
 )
-from snow.request.response import Response
 
 from . import fields
 from .query import Condition, QueryBuilder, select

--- a/snow/session.py
+++ b/snow/session.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import aiohttp
 
-from snow.request.response import Response
+from snow.request import Response
 
 
 class Session(aiohttp.ClientSession):

--- a/tests/app/test_app_session_input.py
+++ b/tests/app/test_app_session_input.py
@@ -1,0 +1,49 @@
+import pytest
+
+from snow import Application, Session
+from snow.exceptions import InvalidSessionType, ConfigurationException
+
+
+def test_app_session_invalid_type():
+    """Invalid object type passed to `session` should raise an InvalidSessionType exception"""
+
+    fail_str = dict(address="test.service-now.com", session="test")
+    fail_int = dict(address="test.service-now.com", session=123)
+
+    with pytest.raises(InvalidSessionType):
+        Application(**fail_str)
+        Application(**fail_int)
+
+
+def test_app_session_no_auth_method():
+    """No authentication method to Application should raise ConfigurationException"""
+
+    with pytest.raises(ConfigurationException):
+        Application("test.service-now.com")
+
+
+def test_app_session_config_full():
+    """Session config should load into a config object"""
+
+    config = dict(
+        address="test.service-now.com",
+        basic_auth=("test", "test"),
+        use_ssl=True,
+        verify_ssl=True,
+    )
+
+    app = Application(**config)
+
+    assert app.config.address == config["address"]
+    assert app.config.session.basic_auth == config["basic_auth"]
+    assert app.config.session.use_ssl == config["use_ssl"]
+    assert app.config.session.verify_ssl == config["verify_ssl"]
+
+
+def test_app_session_object():
+    """Compatible user-provided Session objects should be returned from Application.get_session"""
+
+    session = Session()
+    app = Application("test.service-now.com", session=session)
+
+    assert app.get_session() == session

--- a/tests/app/test_app_session_input.py
+++ b/tests/app/test_app_session_input.py
@@ -1,7 +1,7 @@
 import pytest
 
 from snow import Application, Session
-from snow.exceptions import InvalidSessionType, ConfigurationException
+from snow.exceptions import ConfigurationException, InvalidSessionType
 
 
 def test_app_session_invalid_type():
@@ -13,6 +13,21 @@ def test_app_session_invalid_type():
     with pytest.raises(InvalidSessionType):
         Application(**fail_str)
         Application(**fail_int)
+
+
+def test_app_session_mutual_exclusive():
+    """Passing both a session and session factory configuration should raise ConfigurationException"""
+
+    session = Session()
+
+    with pytest.raises(ConfigurationException):
+        Application("test.service-now.com", session=session, basic_auth=("a", "b"))
+
+    with pytest.raises(ConfigurationException):
+        Application("test.service-now.com", session=session, use_ssl=False)
+
+    with pytest.raises(ConfigurationException):
+        Application("test.service-now.com", session=session, verify_ssl=True)
 
 
 def test_app_session_no_auth_method():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,15 +38,16 @@ def mock_client(aiohttp_client):
 
 
 @pytest.fixture
-def mock_app(mock_client):
+def mock_app_raw():
+    return Application(
+        address="test.service-now.com", basic_auth=("test", "test"), use_ssl=False
+    )
+
+
+@pytest.fixture
+def mock_app(mock_app_raw, mock_client):
     async def go(connect_to):
-        app = Application(
-            config_data=dict(
-                address="test.service-now.com",
-                basic_auth=("test", "test"),
-                use_ssl=False,
-            )
-        )
+        app = mock_app_raw
         get_session = await mock_client(connect_to)
         app.get_session = lambda: get_session
         return app


### PR DESCRIPTION
The `Application` constructor now expects `address` as first positional argument, followed by a set of keyword arguments.

```python
>>> import snow
>>> app = snow.Application(
... "test.service-now.com",
... basic_auth=("test", "testtest"),
... verify_ssl=False)
>>> print(app.config)
<ConfigSegment {'address': 'test.service-now.com', 'session': <ConfigSegment {'use_ssl': True, 'basic_auth': ('test', 'testtest'), 'verify_ssl': False}>}>
```

Also, this PR adds support for passing a snow-compatible `aiohttp.ClientSession` object directly to `snow.Application`.
```python
>>> app = snow.Application(
... "test.service-now.com",
... session=aiohttp.ClientSession(response_class=snow.request.Response))
```

Note:
- Session factory configuration arguments and the *session* argument to `Application` are mutually exclusive, if both are used a `ConfigurationException` is raised.
- Custom `aiohttp.ClientSession` objects must have *response_class* set to  `snow.request.Response`
